### PR TITLE
Fix: add railsContext property serverRenderReactComponent

### DIFF
--- a/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
@@ -93,9 +93,9 @@ JS;
     domNodeId: '$uuid',
     props: props,
     trace: $traceStr,
-    location: ''
+    railsContext: { serverSide: true }
   });
-})()
+})();
 JS;
 
         return $wrapperJs;


### PR DESCRIPTION
When server rendering components I'm getting: 

```
An exception has been thrown during the rendering of a template ("V8Js::compileString():76203: TypeError: Cannot read property 'replace' of undefined").
```

I'm not sure why we did not figure this out earlier, but apparently their internal API changed more than we thought in v5. https://github.com/shakacode/react_on_rails/pull/345/files#diff-741e57aaaefab9559b7892657ec8c75eL270

Instead of passing the location we should pass a `railsContext` now. This is just a quick fix, I think it would be better if we implement the same behaviour in php later (https://github.com/Limenius/ReactRenderer/issues/4)


