### PR TITLE
Implemented a context provider to provide rails context

### DIFF
--- a/src/Limenius/ReactRenderer/Context/ContextProvider.php
+++ b/src/Limenius/ReactRenderer/Context/ContextProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Limenius\ReactRenderer\Context;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class ContextProvider
+ *
+ * Extracts context information from a Symfony Request
+ */
+class ContextProvider
+{
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function getContext($serverSide)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        return [
+            'serverSide' => $serverSide,
+            'href' => $request->getSchemeAndHttpHost().$request->getRequestUri(),
+            'location' => $request->getRequestUri(),
+            'scheme' => $request->getScheme(),
+            'host' => $request->getHost(),
+            'port' => $request->getPort(),
+            'base' => $request->getBaseUrl(),
+            'pathname' => $request->getPathInfo(),
+            'search' => $request->getQueryString(),
+            ];
+    }
+
+}

--- a/src/Limenius/ReactRenderer/Context/ContextProviderInterface.php
+++ b/src/Limenius/ReactRenderer/Context/ContextProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Limenius\ReactRenderer\Context;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Interface ContextProviderInterface
+ *
+ * Provides context
+ */
+interface ContextProviderInterface
+{
+    /**
+     * getContext
+     *
+     * @param boolean $serverSide whether is this a server side context
+     */
+    public function getContext($serverSide);
+}

--- a/src/Limenius/ReactRenderer/Context/SymfonyContextProvider.php
+++ b/src/Limenius/ReactRenderer/Context/SymfonyContextProvider.php
@@ -9,15 +9,25 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *
  * Extracts context information from a Symfony Request
  */
-class ContextProvider
+class SymfonyContextProvider implements ContextProviderInterface
 {
     private $requestStack;
 
+    /**
+     * __construct
+     *
+     * @param RequestStack $requestStack
+     */
     public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
     }
 
+    /**
+     * getContext
+     *
+     * @param boolean $serverSide whether is this a server side context
+     */
     public function getContext($serverSide)
     {
         $request = $this->requestStack->getCurrentRequest();
@@ -31,7 +41,7 @@ class ContextProvider
             'base' => $request->getBaseUrl(),
             'pathname' => $request->getPathInfo(),
             'search' => $request->getQueryString(),
-            ];
+        ];
     }
 
 }

--- a/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
@@ -4,6 +4,7 @@ namespace Limenius\ReactRenderer\Renderer;
 
 use Limenius\ReactRenderer\Exception\EvalJsException;
 use Psr\Log\LoggerInterface;
+use Limenius\ReactRenderer\Context\ContextProvider;
 
 /**
  * Class AbstractReactRenderer
@@ -14,6 +15,11 @@ abstract class AbstractReactRenderer
      * @var LoggerInterface
      */
     protected $logger;
+
+    /**
+     * @var ContextProvider
+     */
+    protected $contextProvider;
 
     /**
      * @param string $componentName
@@ -84,6 +90,7 @@ JS;
     {
         $traceStr = $trace ? 'true' : 'false';
         $initializedReduxStores = $this->initializeReduxStores($registeredStores);
+        $context = json_encode($this->contextProvider->getContext(true));
         $wrapperJs = <<<JS
 (function() {
   $initializedReduxStores
@@ -93,7 +100,7 @@ JS;
     domNodeId: '$uuid',
     props: props,
     trace: $traceStr,
-    railsContext: { serverSide: true }
+    railsContext: $context,
   });
 })();
 JS;

--- a/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
@@ -58,7 +58,7 @@ JS;
      *
      * @return string
      */
-    protected function initializeReduxStores($registeredStores = array())
+    protected function initializeReduxStores($registeredStores = array(), $context = array())
     {
         if (!is_array($registeredStores) || empty($registeredStores)) {
             return '';
@@ -68,8 +68,9 @@ JS;
         foreach ($registeredStores as $storeName => $reduxProps) {
             $result .= <<<JS
 reduxProps = $reduxProps;
+context = $context;
 storeGenerator = ReactOnRails.getStoreGenerator('$storeName');
-store = storeGenerator(reduxProps);
+store = storeGenerator(reduxProps, context);
 ReactOnRails.setStore('$storeName', store);
 JS;
         }
@@ -89,8 +90,8 @@ JS;
     protected function wrap($name, $propsString, $uuid, $registeredStores = array(), $trace)
     {
         $traceStr = $trace ? 'true' : 'false';
-        $initializedReduxStores = $this->initializeReduxStores($registeredStores);
         $context = json_encode($this->contextProvider->getContext(true));
+        $initializedReduxStores = $this->initializeReduxStores($registeredStores, $context);
         $wrapperJs = <<<JS
 (function() {
   $initializedReduxStores

--- a/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
@@ -3,6 +3,7 @@
 namespace Limenius\ReactRenderer\Renderer;
 
 use Psr\Log\LoggerInterface;
+use Limenius\ReactRenderer\Context\ContextProvider;
 
 /**
  * Class ExternalServerReactRenderer
@@ -24,13 +25,15 @@ class ExternalServerReactRenderer extends AbstractReactRenderer
      *
      * @param string          $serverSocketPath
      * @param bool            $failLoud
+     * @param ContextProvider $contextProvider
      * @param LoggerInterface $logger
      */
-    public function __construct($serverSocketPath, $failLoud = false, LoggerInterface $logger = null)
+    public function __construct($serverSocketPath, $failLoud = false, ContextProvider $contextProvider, LoggerInterface $logger = null)
     {
         $this->serverSocketPath = $serverSocketPath;
         $this->failLoud = $failLoud;
         $this->logger = $logger;
+        $this->contextProvider = $contextProvider;
     }
 
     /**

--- a/src/Limenius/ReactRenderer/Renderer/PhpExecJsReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/PhpExecJsReactRenderer.php
@@ -4,6 +4,7 @@ namespace Limenius\ReactRenderer\Renderer;
 
 use Nacmartin\PhpExecJs\PhpExecJs;
 use Psr\Log\LoggerInterface;
+use Limenius\ReactRenderer\Context\ContextProvider;
 
 /**
  * Class PhpExecJsReactRenderer
@@ -37,11 +38,12 @@ class PhpExecJsReactRenderer extends AbstractReactRenderer
      * @param bool            $failLoud
      * @param LoggerInterface $logger
      */
-    public function __construct($serverBundlePath, $failLoud = false, LoggerInterface $logger = null)
+    public function __construct($serverBundlePath, $failLoud = false, ContextProvider $contextProvider, LoggerInterface $logger = null)
     {
         $this->serverBundlePath = $serverBundlePath;
         $this->failLoud = $failLoud;
         $this->logger = $logger;
+        $this->contextProvider = $contextProvider;
     }
 
     /**

--- a/src/Limenius/ReactRenderer/Renderer/PhpExecJsReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/PhpExecJsReactRenderer.php
@@ -4,7 +4,7 @@ namespace Limenius\ReactRenderer\Renderer;
 
 use Nacmartin\PhpExecJs\PhpExecJs;
 use Psr\Log\LoggerInterface;
-use Limenius\ReactRenderer\Context\ContextProvider;
+use Limenius\ReactRenderer\Context\ContextProviderInterface;
 
 /**
  * Class PhpExecJsReactRenderer
@@ -38,7 +38,7 @@ class PhpExecJsReactRenderer extends AbstractReactRenderer
      * @param bool            $failLoud
      * @param LoggerInterface $logger
      */
-    public function __construct($serverBundlePath, $failLoud = false, ContextProvider $contextProvider, LoggerInterface $logger = null)
+    public function __construct($serverBundlePath, $failLoud = false, ContextProviderInterface $contextProvider, LoggerInterface $logger = null)
     {
         $this->serverBundlePath = $serverBundlePath;
         $this->failLoud = $failLoud;

--- a/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
+++ b/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
@@ -73,29 +73,31 @@ class ReactRenderExtension extends \Twig_Extension
         $propsArray = is_array($props) ? $props : json_decode($props);
 
         $str = '';
-        $domId = 'sfreact-'.uniqid('reactRenderer', true);
-        $data = $propsArray;
-        $trace = $this->shouldTrace($options);
+        $data = array(
+            'component_name' => $componentName,
+            'props' => $propsArray,
+            'dom_id' => 'sfreact-'.uniqid('reactRenderer', true),
+            'trace' => $this->shouldTrace($options),
+        );
 
 
         if ($this->shouldRenderClientSide($options)) {
             $str .= $this->renderContext();
             $str .=  sprintf(
-                '<script type="application/json" class="js-react-on-rails-component" data-dom-id="%s" data-component-name="%s" %s>%s</script>',
-                $domId,
-                $componentName,
-                $trace ? 'trace' : '',
-                json_encode($data)
+                '<script type="application/json" class="js-react-on-rails-component" data-component-name="%s" data-dom-id="%s">%s</script>',
+                $data['component_name'],
+                $data['dom_id'],
+                json_encode($data['props'])
             );
         }
-        $str .= '<div id="'.$domId.'">';
+        $str .= '<div id="'.$data['dom_id'].'">';
         if ($this->shouldRenderServerSide($options)) {
             $serverSideStr = $this->renderer->render(
-                $componentName,
-                json_encode($data),
-                $domId,
+                $data['component_name'],
+                json_encode($data['props']),
+                $data['dom_id'],
                 $this->registeredStores,
-                $trace
+                $data['trace']
             );
             $str .= $serverSideStr;
         }

--- a/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
+++ b/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
@@ -3,7 +3,7 @@
 namespace Limenius\ReactRenderer\Twig;
 
 use Limenius\ReactRenderer\Renderer\AbstractReactRenderer;
-use Limenius\ReactRenderer\Context\ContextProvider;
+use Limenius\ReactRenderer\Context\ContextProviderInterface;
 
 /**
  * Class ReactRenderExtension
@@ -13,7 +13,7 @@ class ReactRenderExtension extends \Twig_Extension
     protected $renderServerSide = false;
     protected $renderClientSide = false;
     protected $registeredStores = array();
-    protected $needsRailsContext = true;
+    protected $needsToSetRailsContext = true;
 
     private $renderer;
     private $contextProvider;
@@ -28,7 +28,7 @@ class ReactRenderExtension extends \Twig_Extension
      *
      * @return ReactRenderExtension
      */
-    public function __construct(AbstractReactRenderer $renderer = null, ContextProvider $contextProvider, $defaultRendering, $trace = false)
+    public function __construct(AbstractReactRenderer $renderer = null, ContextProviderInterface $contextProvider, $defaultRendering, $trace = false)
     {
         $this->renderer = $renderer;
         $this->contextProvider = $contextProvider;
@@ -181,12 +181,12 @@ class ReactRenderExtension extends \Twig_Extension
     /**
      * renderContext
      *
-     * @return string a html with the context
+     * @return string a html script tag with the context
      */
     protected function renderContext()
     {
-        if ($this->needsRailsContext) {
-            $this->needsRailsContext = false;
+        if ($this->needsToSetRailsContext) {
+            $this->needsToSetRailsContext = false;
             return sprintf(
                 '<script type="application/json" id="js-react-on-rails-context">%s</script>',
                 json_encode($this->contextProvider->getContext(false))


### PR DESCRIPTION
As pointed out in #4 it would be nice to populate rails context with some context about the request. I  have done a first try, mimicking the object that creates React on Rails. This is conservative. However, I think that since we are using a Symfony Request it would make more sense to use more "symfonic" keys for the array. So, instead of `search`, `queryString`; instead of `pathname`, `pathInfo`. The same case with `requestUri`and `baseUrl`.

````
            'serverSide' => $serverSide,
            'href' => $request->getSchemeAndHttpHost().$request->getRequestUri(),
            'location' => $request->getRequestUri(),
            'scheme' => $request->getScheme(),
            'host' => $request->getHost(),
            'port' => $request->getPort(),
            'base' => $request->getBaseUrl(),
            'pathname' => $request->getPathInfo(),
            'search' => $request->getQueryString(),
````

Does this make sense? Any other comments?