### PR TITLE
add compatibility with es5's strict mode

### DIFF
--- a/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/AbstractReactRenderer.php
@@ -64,7 +64,7 @@ JS;
             return '';
         }
 
-        $result = '';
+        $result = 'var reduxProps, context, storeGenerator, store' . PHP_EOL;
         foreach ($registeredStores as $storeName => $reduxProps) {
             $result .= <<<JS
 reduxProps = $reduxProps;


### PR DESCRIPTION
The following code does not work in ES5's strict mode:
```
(function() {
  'use strict';
  reduxProps = {"models":[{}, {}]};
})();
```
The variables has to be declared before use:
```
(function() {
  'use strict';
  var reduxProps;
  reduxProps = {"models":[{}, {}]};
})();
```