### PR TITLE
Use stream_socket_sendto and stream_socket_shutdown instead of fwrite

### DIFF
--- a/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
@@ -60,7 +60,8 @@ class ExternalServerReactRenderer extends AbstractReactRenderer
         }
 
         $sock = stream_socket_client($this->serverSocketPath, $errno, $errstr);
-        fwrite($sock, $this->wrap($componentName, $propsString, $uuid, $registeredStores, $trace));
+        stream_socket_sendto($sock, $this->wrap($componentName, $propsString, $uuid, $registeredStores, $trace));
+        stream_socket_shutdown($sock, STREAM_SHUT_WR);
 
         $contents = '';
 

--- a/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
@@ -60,8 +60,7 @@ class ExternalServerReactRenderer extends AbstractReactRenderer
         }
 
         $sock = stream_socket_client($this->serverSocketPath, $errno, $errstr);
-        stream_socket_sendto($sock, $this->wrap($componentName, $propsString, $uuid, $registeredStores, $trace));
-        stream_socket_shutdown($sock, STREAM_SHUT_WR);
+        stream_socket_sendto($sock, $this->wrap($componentName, $propsString, $uuid, $registeredStores, $trace)."\0");
 
         $contents = '';
 


### PR DESCRIPTION
Using stream_socket_sendto and stream_socket_shutdown allows for receiving arbitrary amounts of data on the nodeJS side and then sending the response on the "finish" event. Otherwise, for large amounts of data, the data is truncated if the response is sent in the "data" event, or if it if moved to the 'end' or 'finish' events, these are never called.