### PR TITLE
Fix infinit loop when stream_socket_client return false

### DIFF
--- a/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
@@ -59,7 +59,9 @@ class ExternalServerReactRenderer extends AbstractReactRenderer
             $this->serverSocketPath = 'unix://'.$this->serverSocketPath;
         }
 
-        $sock = stream_socket_client($this->serverSocketPath, $errno, $errstr);
+        if (!$sock = stream_socket_client($this->serverSocketPath, $errno, $errstr)) {
+            throw new \RuntimeException($errstr);
+        }
         stream_socket_sendto($sock, $this->wrap($componentName, $propsString, $uuid, $registeredStores, $trace)."\0");
 
         $contents = '';


### PR DESCRIPTION
Hi

I have an issue with the package. When my SSR server is down, my PHP app fails: `Error: Maximum execution time of 30 seconds exceeded`

If you don't check `stream_socket_client`, `$sock` could be equals to `false`.
```php
while (!feof($sock)) { // while (true)
```
https://3v4l.org/OWO3q


```
error_reporting | fread() expects parameter 1 to be resource, boolean given
line            | 68
code            | 2
file            | /app/vendor/limenius/react-renderer/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
```