### PR TITLE
handle json encode/decode problems with checking on last error

### DIFF
--- a/src/Limenius/ReactRenderer/Exception/PropsDecodeException.php
+++ b/src/Limenius/ReactRenderer/Exception/PropsDecodeException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Limenius\ReactRenderer\Exception;
+
+/**
+ * Class PropsEncodeException
+ */
+class PropsDecodeException extends \RuntimeException
+{
+}

--- a/src/Limenius/ReactRenderer/Exception/PropsEncodeException.php
+++ b/src/Limenius/ReactRenderer/Exception/PropsEncodeException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Limenius\ReactRenderer\Exception;
+
+/**
+ * Class PropsEncodeException
+ */
+class PropsEncodeException extends \RuntimeException
+{
+}

--- a/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
+++ b/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
@@ -330,7 +330,7 @@ class ReactRenderExtension extends \Twig_Extension
     {
         $json = json_encode($input);
 
-        if (json_last_error() !== null) {
+        if (json_last_error() !== 0) {
             throw new \Limenius\ReactRenderer\Exception\PropsEncodeException(
                 sprintf(
                     'JSON could not be encoded, Error Message was %s',
@@ -346,7 +346,7 @@ class ReactRenderExtension extends \Twig_Extension
     {
         $json = json_decode($input);
 
-        if (json_last_error() !== null) {
+        if (json_last_error() !== 0) {
             throw new \Limenius\ReactRenderer\Exception\PropsDecodeException(
                 sprintf(
                     'JSON could not be decoded, Error Message was %s',

--- a/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
+++ b/src/Limenius/ReactRenderer/Twig/ReactRenderExtension.php
@@ -83,7 +83,7 @@ class ReactRenderExtension extends \Twig_Extension
     public function reactRenderComponentArray($componentName, array $options = array(), $bufferData = false)
     {
         $props = isset($options['props']) ? $options['props'] : array();
-        $propsArray = is_array($props) ? $props : json_decode($props);
+        $propsArray = is_array($props) ? $props : $this->jsonDecode($props);
 
         $str = '';
         $data = array(
@@ -100,7 +100,7 @@ class ReactRenderExtension extends \Twig_Extension
                 '<script type="application/json" class="js-react-on-rails-component" data-component-name="%s" data-dom-id="%s">%s</script>',
                 $data['component_name'],
                 $data['dom_id'],
-                json_encode($data['props'])
+                $this->jsonEncode($data['props'])
             );
             if($bufferData === true) {
                 $this->buffer[] = $tmpData;
@@ -113,7 +113,7 @@ class ReactRenderExtension extends \Twig_Extension
         if ($this->shouldRenderServerSide($options)) {
             $rendered = $this->renderer->render(
                 $data['component_name'],
-                json_encode($data['props']),
+                $this->jsonEncode($data['props']),
                 $data['dom_id'],
                 $this->registeredStores,
                 $data['trace']
@@ -159,7 +159,7 @@ class ReactRenderExtension extends \Twig_Extension
     public function reactRenderComponent($componentName, array $options = array(), $bufferData = false)
     {
         $props = isset($options['props']) ? $options['props'] : array();
-        $propsArray = is_array($props) ? $props : json_decode($props);
+        $propsArray = is_array($props) ? $props : $this->jsonDecode($props);
 
         $str = '';
         $data = array(
@@ -176,7 +176,7 @@ class ReactRenderExtension extends \Twig_Extension
                 '<script type="application/json" class="js-react-on-rails-component" data-component-name="%s" data-dom-id="%s">%s</script>',
                 $data['component_name'],
                 $data['dom_id'],
-                json_encode($data['props'])
+                $this->jsonEncode($data['props'])
             );
             if($bufferData === true) {
                 $this->buffer[] = $tmpData;
@@ -188,7 +188,7 @@ class ReactRenderExtension extends \Twig_Extension
         if ($this->shouldRenderServerSide($options)) {
             $rendered = $this->renderer->render(
                 $data['component_name'],
-                json_encode($data['props']),
+                $this->jsonEncode($data['props']),
                 $data['dom_id'],
                 $this->registeredStores,
                 $data['trace']
@@ -224,7 +224,7 @@ class ReactRenderExtension extends \Twig_Extension
      */
     public function reactReduxStore($storeName, $props)
     {
-        $propsString = is_array($props) ? json_encode($props) : $props;
+        $propsString = is_array($props) ? $this->jsonEncode($props) : $props;
         $this->registeredStores[$storeName] = $propsString;
 
 
@@ -319,10 +319,42 @@ class ReactRenderExtension extends \Twig_Extension
 
             return sprintf(
                 '<script type="application/json" id="js-react-on-rails-context">%s</script>',
-                json_encode($this->contextProvider->getContext(false))
+                $this->jsonEncode($this->contextProvider->getContext(false))
             );
         }
 
         return '';
+    }
+
+    protected function jsonEncode($input)
+    {
+        $json = json_encode($input);
+
+        if (json_last_error() !== null) {
+            throw new \Limenius\ReactRenderer\Exception\PropsEncodeException(
+                sprintf(
+                    'JSON could not be encoded, Error Message was %s',
+                    json_last_error_msg()
+                )
+            );
+        }
+
+        return $json;
+    }
+
+    protected function jsonDecode($input)
+    {
+        $json = json_decode($input);
+
+        if (json_last_error() !== null) {
+            throw new \Limenius\ReactRenderer\Exception\PropsDecodeException(
+                sprintf(
+                    'JSON could not be decoded, Error Message was %s',
+                    json_last_error_msg()
+                )
+            );
+        }
+
+        return $json;
     }
 }


### PR DESCRIPTION
With a broken umlaut supplied as props in React, it is possible that the json_encode on PHP site fails. 
These broken props (false) were send to V8JS and let to an V8JSException.

This patch checks now the json_encode/decode operations for last error and raises Exceptions if needed. 
