### PR TITLE
Fail loud should apply consistently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,16 @@
         }
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.1.0",
         "nacmartin/phpexecjs": "^2.0",
+        "psr/cache": "^1.0.0",
+        "psr/log": "^1.1.0",
         "twig/twig": "^1.20|^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",
         "escapestudios/symfony2-coding-standard": "^2.9",
+        "phpunit/phpunit": "^7.5.0",
         "wimg/php-compatibility": "^7.0"
     },
     "scripts": {


### PR DESCRIPTION
As we understand it, the intent behind `fail_loud` is to allow graceful degradation to client-side-only rendering in production if SSR fails.  The current implementation currently only supports this for errors returned by the JS rendering implementation, rather than generated by the PHP renderer itself.  This PR changes `fail_loud: false` to universally prevent SSR-originating errors from preventing page rendering.  If this is not a desired change, an alternative would be to add a separate option to control this behavior.

This change required bumping the minimum PHP version to permit `\Throwable`, I hope this is acceptable as at this point such versions are long past EOL.