### PR TITLE
opt-in phpexecjs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,17 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "nacmartin/phpexecjs": "^2.0",
         "twig/twig": "^1.20|^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",
         "escapestudios/symfony2-coding-standard": "^2.9",
-        "wimg/php-compatibility": "^7.0"
+        "wimg/php-compatibility": "^7.0",
+        "nacmartin/phpexecjs": "^2.0"
+    },
+    "suggest": {
+        "ext-sockets": "Needs to support external SSR in class ExternalServerReactRenderer",
+        "nacmartin/phpexecjs": "Needed to support phpexecjs in class PhpExecJsReactRenderer"
     },
     "scripts": {
         "default-scripts": [

--- a/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/ExternalServerReactRenderer.php
@@ -34,6 +34,10 @@ class ExternalServerReactRenderer extends AbstractReactRenderer
         $this->failLoud = $failLoud;
         $this->logger = $logger;
         $this->contextProvider = $contextProvider;
+
+        if (!\extension_loaded('sockets')) {
+            throw new \RuntimeException(\sprintf('Please enable ext-sockets before using %s', __CLASS__));
+        }
     }
 
     /**

--- a/src/Limenius/ReactRenderer/Renderer/PhpExecJsReactRenderer.php
+++ b/src/Limenius/ReactRenderer/Renderer/PhpExecJsReactRenderer.php
@@ -57,6 +57,10 @@ class PhpExecJsReactRenderer extends AbstractReactRenderer
         $this->failLoud = $failLoud;
         $this->logger = $logger;
         $this->contextProvider = $contextProvider;
+
+        if (!\class_exists('\Nacmartin\PhpExecJs\PhpExecJs')) {
+            throw new \RuntimeException(\sprintf('Please install nacmartin/phpexecjs before using %s', __CLASS__));
+        }
     }
 
     public function setCache(CacheItemPoolInterface $cache, $cacheKey)


### PR DESCRIPTION
Installation of `nacmartin/phpexecjs` should not be forced because user may want to use external SSR.
So phpexecjs should be an opt-in dependency.