### PR TITLE
PHPCS/Composer: update PHPCompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
     - composer update $COMPOSER_FLAGS
 
 script:
-    #    - ./vendor/bin/phpcs --standard=ruleset.xml -p
+    #    - ./vendor/bin/phpcs -p
     - phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.2.0",
         "ext-json": "*",
         "nacmartin/phpexecjs": "^3.0",
         "twig/twig": "^2.4|^3.0"
@@ -27,18 +27,8 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",
         "escapestudios/symfony2-coding-standard": "^2.9",
-        "wimg/php-compatibility": "^7.0",
-        "phpstan/phpstan": "^0.11.19"
-    },
-    "scripts": {
-        "default-scripts": [
-            "rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility"
-        ],
-        "post-install-cmd": [
-            "@default-scripts"
-        ],
-        "post-update-cmd": [
-            "@default-scripts"
-        ]
+        "phpcompatibility/php-compatibility": "^9.0",
+        "phpstan/phpstan": "^0.11.19",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,10 +5,10 @@
     <exclude-pattern>vendor/</exclude-pattern>
     <exclude-pattern>Resources/</exclude-pattern>
 
-    <rule ref="vendor/escapestudios/symfony2-coding-standard/Symfony2"/>
-    <rule ref="vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility" />
+    <rule ref="Symfony2"/>
+    <rule ref="PHPCompatibility"/>
 
-    <config name="testVersion" value="5.5-7.0"/>
+    <config name="testVersion" value="7.2-"/>
 
     <rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd">
         <severity>0</severity>


### PR DESCRIPTION
## Composer:
* `wimg/php-compatibility` has been abandoned for over a year. Use `phpcompatibility/php-compatibility` instead.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with PHP 7.4.
* As of PHPCompatibility 8.0, the directory layout of the PHPCompatibility standard has been updated to work correctly with Composer, so no need for the custom scripts moving the files anymore.
* Add the DealerDirect Composer PHPCS plugin.
    This plugin will handle setting the PHPCS `installed_paths` automatically.
    This also allows for referencing the rulesets by name instead of via the path in the ruleset, which is generally more stable.
* Update the minimum PHP version `require`d, which based on commit https://github.com/Limenius/ReactRenderer/commit/5446eee99b36c88a7e4199f838667f7ff8520f70 is now PHP 7.2.

## PHPCS ruleset:
* Rename the ruleset to `phpcs.xml.dist` which will allow PHPCS to automatically pick up on it.
    No need to pass the `--standard=...` command-line argument anymore.
    Includes removing the argument from the Travis script.
* Check for cross-version compatibility for the PHP versions officially supported.
    According to the `composer.json` file, this code should be compatible with PHP 5.5 and above. Based on the above mentioned commit, however, the minimum supported PHP version is PHP 7.2.
    PHPCompatibility _was_ checking against PHP 5.5 up to PHP 7.0.
    The new `testVersion` actually checks against PHP 7.2 up to the latest version (7.4 at this moment).

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer

## Additional suggestions:
* You may also want to update the Symfony standard dependency which is currently at version ~~`3.10.0`~~ `3.11.0`
    Ref: https://github.com/djoos/Symfony-coding-standard/blob/master/UPGRADE-3.0.md
    Note: the ruleset name has been changed in version 3 from `Symfony2` to `Symfony`.
* And consider updating (or removing) the PHP_CodeSniffer dependency, of which the latest release is version ~~`3.5.3`~~ `3.5.6`
    I'd suggest removing it as it is not _your_ dependency, but a dependency of the PHPCompatibility and the Symfony coding standards, so let those dependencies manage the version rather than doing that yourself.
    Ref: https://github.com/squizlabs/php_codesniffer/releases
* Enabling the PHPCS check in Travis would also help.