### PR TITLE
Added GenericContextProvider

### DIFF
--- a/src/Limenius/ReactRenderer/Context/GenericContextProvider.php
+++ b/src/Limenius/ReactRenderer/Context/GenericContextProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Limenius\ReactRenderer\Context;
+
+/**
+ * Class ContextProvider
+ *
+ * Extracts context information from a URI path.
+ * https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
+ */
+class GenericContextProvider implements ContextProviderInterface
+{
+    private $regex = '/(?<scheme>https?):\/\/(?<host>.*(\.[^\/(?:\d*)]*))(?::(?<port>\d*))(?<uri>(?<base>\/?[^\.]*\.[^\/\?]*)?(?<path>[^?\.*]*)\??(?<search>.*))/';
+    private $uriParts;
+
+    public function __construct(string $uri)
+    {
+        preg_match($this->regex, $uri, $this->uriParts, PREG_OFFSET_CAPTURE);
+    }
+
+    private function getRequestUri()
+    {
+        return $this->uriParts['uri'][0] ?: '/';
+    }
+
+    private function getScheme()
+    {
+        return $this->uriParts['scheme'][0];
+    }
+
+    private function getHost()
+    {
+        return $this->uriParts['host'][0];
+    }
+
+    private function getPort()
+    {
+        return $this->uriParts['port'][0];
+    }
+
+    private function getBase()
+    {
+        return $this->uriParts['base'][0];
+    }
+
+    private function getPathName()
+    {
+        return $this->uriParts['path'][0];
+    }
+
+    private function getSearch()
+    {
+        return $this->uriParts['search'][0];
+    }
+
+    /**
+     * getContext
+     *
+     * @param boolean $serverSide whether is this a server side context
+     * @return array the context information
+     */
+    public function getContext($serverSide)
+    {
+        return [
+            'serverSide' => $serverSide,
+            'href' => $this->uriParts[0][0],
+            'location' => $this->getRequestUri(),
+            'scheme' => $this->getScheme(),
+            'host' => $this->getHost(),
+            'port' => $this->getPort(),
+            'base' => $this->getBase(),
+            'pathname' => $this->getPathName(),
+            'search' => $this->getSearch(),
+        ];
+    }
+}

--- a/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
+++ b/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Limenius\ReactRenderer\Tests\Context;
+
+use Limenius\ReactRenderer\Context\GenericContextProvider;
+use PHPUnit\Framework\TestCase;
+
+class GenericContextProviderTest extends TestCase
+{
+    public function testGetHref()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar', $context['href']);
+    }
+
+    public function testGetRequestUri1()
+    {
+        $provider = new GenericContextProvider('https://example.com:443');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['location']);
+    }
+
+    public function testGetRequestUri2()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['location']);
+    }
+
+    public function testGetRequestUri3()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part', $context['location']);
+    }
+
+    public function testGetRequestUri4()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part?foo=bar', $context['location']);
+    }
+
+    public function testGetRequestUri5()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/index.php/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/index.php/part?foo=bar', $context['location']);
+    }
+
+    public function testGetScheme1()
+    {
+        $provider = new GenericContextProvider('http://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('http', $context['scheme']);
+    }
+
+    public function testGetScheme2()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('https', $context['scheme']);
+    }
+
+    public function testGetHost1()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('example.com', $context['host']);
+    }
+
+    public function testGetHost2()
+    {
+        $provider = new GenericContextProvider('https://sub.example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('sub.example.com', $context['host']);
+    }
+
+    public function testGetPort1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('8089', $context['port']);
+    }
+
+    public function testGetPort2()
+    {
+        $provider = new GenericContextProvider('https://sub.example.com/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['port']);
+    }
+
+    public function testGetBaseUrl1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['base']);
+    }
+
+    public function testGetBaseUrl2()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/index.php', $context['base']);
+    }
+
+    public function testGetPathName1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['pathname']);
+    }
+
+    public function testGetPathName2()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['pathname']);
+    }
+
+    public function testGetPathName3()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part', $context['pathname']);
+    }
+
+    public function testGetPathName4()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part/sub', $context['pathname']);
+    }
+
+    public function testGetSearch1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['search']);
+    }
+
+    public function testGetSearch2()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['search']);
+    }
+
+    public function testGetSearch3()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('foo=bar', $context['search']);
+    }
+
+    public function testGetSearch4()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar&bar=baz');
+        $context = $provider->getContext(false);
+        $this->assertEquals('foo=bar&bar=baz', $context['search']);
+    }
+}


### PR DESCRIPTION
Added a GenericContextProvider for making this package usable for non-Symfony projects.

We are currently using this package as part of a Symfony project, and we would like to add it to a Wordpress project to enable react server side rendering. This GenericContextProvider let's do just that.
