### PR TITLE
GenericContextProvider

### DIFF
--- a/src/Limenius/ReactRenderer/Context/GenericContextProvider.php
+++ b/src/Limenius/ReactRenderer/Context/GenericContextProvider.php
@@ -10,7 +10,7 @@ namespace Limenius\ReactRenderer\Context;
  */
 class GenericContextProvider implements ContextProviderInterface
 {
-    private $regex = '/(?<scheme>https?):\/\/(?<host>.*(\.[^\/(?:\d*)]*))(?::(?<port>\d*))(?<uri>(?<base>\/?[^\.]*\.[^\/\?]*)?(?<path>[^?\.*]*)\??(?<search>.*))/';
+    private $regex = '/(?<scheme>https?):\/\/(?<host>[^\/|:]*)(?::(?<port>\d*))?(?<uri>(?<base>\/?[^\.]*\.[^\/\?]*)?(?<path>[^?\.*]*)\??(?<search>.*))/';
     private $uriParts;
 
     public function __construct(string $uri)

--- a/src/Limenius/ReactRenderer/Context/GenericContextProvider.php
+++ b/src/Limenius/ReactRenderer/Context/GenericContextProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Limenius\ReactRenderer\Context;
+
+/**
+ * Class ContextProvider
+ *
+ * Extracts context information from a URI path.
+ * https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
+ */
+class GenericContextProvider implements ContextProviderInterface
+{
+    private $regex = '/(?<scheme>https?):\/\/(?<host>.*(\.[^\/(?:\d*)]*))(?::(?<port>\d*))(?<uri>(?<base>\/?[^\.]*\.[^\/\?]*)?(?<path>[^?\.*]*)\??(?<search>.*))/';
+    private $uriParts;
+
+    public function __construct(string $uri)
+    {
+        preg_match($this->regex, $uri, $this->uriParts, PREG_OFFSET_CAPTURE);
+    }
+
+    private function getRequestUri()
+    {
+        return $this->uriParts['uri'][0] ?: '/';
+    }
+
+    private function getScheme()
+    {
+        return $this->uriParts['scheme'][0];
+    }
+
+    private function getHost()
+    {
+        return $this->uriParts['host'][0];
+    }
+
+    private function getPort()
+    {
+        return $this->uriParts['port'][0];
+    }
+
+    private function getBase()
+    {
+        return $this->uriParts['base'][0];
+    }
+
+    private function getPathName()
+    {
+        return $this->uriParts['path'][0];
+    }
+
+    private function getSearch()
+    {
+        return $this->uriParts['search'][0];
+    }
+
+    /**
+     * getContext
+     *
+     * @param boolean $serverSide whether is this a server side context
+     * @return array the context information
+     */
+    public function getContext($serverSide)
+    {
+        return [
+            'serverSide' => $serverSide,
+            'href' => $this->uriParts[0][0],
+            'location' => $this->getRequestUri(),
+            'scheme' => $this->getScheme(),
+            'host' => $this->getHost(),
+            'port' => $this->getPort(),
+            'base' => $this->getBase(),
+            'pathname' => $this->getPathName(),
+            'search' => $this->getSearch(),
+        ];
+    }
+}

--- a/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
+++ b/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Limenius\ReactRenderer\Tests\Context;
+
+use Limenius\ReactRenderer\Context\GenericContextProvider;
+use PHPUnit\Framework\TestCase;
+
+class GenericContextProviderTest extends TestCase
+{
+    public function testGetHref()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar', $context['href']);
+    }
+
+    public function testGetRequestUri1()
+    {
+        $provider = new GenericContextProvider('https://example.com:443');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['location']);
+    }
+
+    public function testGetRequestUri2()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['location']);
+    }
+
+    public function testGetRequestUri3()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part', $context['location']);
+    }
+
+    public function testGetRequestUri4()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part?foo=bar', $context['location']);
+    }
+
+    public function testGetRequestUri5()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/index.php/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/index.php/part?foo=bar', $context['location']);
+    }
+
+    public function testGetScheme1()
+    {
+        $provider = new GenericContextProvider('http://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('http', $context['scheme']);
+    }
+
+    public function testGetScheme2()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('https', $context['scheme']);
+    }
+
+    public function testGetHost1()
+    {
+        $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('example.com', $context['host']);
+    }
+
+    public function testGetHost2()
+    {
+        $provider = new GenericContextProvider('https://sub.example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('sub.example.com', $context['host']);
+    }
+
+    public function testGetPort1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('8089', $context['port']);
+    }
+
+    public function testGetPort2()
+    {
+        $provider = new GenericContextProvider('https://sub.example.com/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['port']);
+    }
+
+    public function testGetBaseUrl1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['base']);
+    }
+
+    public function testGetBaseUrl2()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/index.php', $context['base']);
+    }
+
+    public function testGetPathName1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['pathname']);
+    }
+
+    public function testGetPathName2()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/', $context['pathname']);
+    }
+
+    public function testGetPathName3()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part', $context['pathname']);
+    }
+
+    public function testGetPathName4()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('/part/sub', $context['pathname']);
+    }
+
+    public function testGetSearch1()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['search']);
+    }
+
+    public function testGetSearch2()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?');
+        $context = $provider->getContext(false);
+        $this->assertEquals('', $context['search']);
+    }
+
+    public function testGetSearch3()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('foo=bar', $context['search']);
+    }
+
+    public function testGetSearch4()
+    {
+        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar&bar=baz');
+        $context = $provider->getContext(false);
+        $this->assertEquals('foo=bar&bar=baz', $context['search']);
+    }
+}

--- a/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
+++ b/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
@@ -18,6 +18,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:443');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:443', $context['href']);
         $this->assertEquals('/', $context['location']);
     }
 
@@ -25,6 +26,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:443/');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:443/', $context['href']);
         $this->assertEquals('/', $context['location']);
     }
 
@@ -32,6 +34,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:443/part');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:443/part', $context['href']);
         $this->assertEquals('/part', $context['location']);
     }
 
@@ -39,6 +42,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:443/part?foo=bar', $context['href']);
         $this->assertEquals('/part?foo=bar', $context['location']);
     }
 
@@ -46,6 +50,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:443/index.php/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:443/index.php/part?foo=bar', $context['href']);
         $this->assertEquals('/index.php/part?foo=bar', $context['location']);
     }
 
@@ -53,6 +58,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('http://example.com:443/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('http://example.com:443/part?foo=bar', $context['href']);
         $this->assertEquals('http', $context['scheme']);
     }
 
@@ -60,6 +66,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:443/part?foo=bar', $context['href']);
         $this->assertEquals('https', $context['scheme']);
     }
 
@@ -67,6 +74,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:443/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:443/part?foo=bar', $context['href']);
         $this->assertEquals('example.com', $context['host']);
     }
 
@@ -74,6 +82,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://sub.example.com:443/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://sub.example.com:443/part?foo=bar', $context['href']);
         $this->assertEquals('sub.example.com', $context['host']);
     }
 
@@ -81,6 +90,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/part?foo=bar', $context['href']);
         $this->assertEquals('8089', $context['port']);
     }
 
@@ -88,6 +98,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://sub.example.com/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://sub.example.com/part?foo=bar', $context['href']);
         $this->assertEquals('', $context['port']);
     }
 
@@ -95,6 +106,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/part?foo=bar', $context['href']);
         $this->assertEquals('', $context['base']);
     }
 
@@ -102,6 +114,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php?foo=bar', $context['href']);
         $this->assertEquals('/index.php', $context['base']);
     }
 
@@ -109,6 +122,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/?foo=bar', $context['href']);
         $this->assertEquals('/', $context['pathname']);
     }
 
@@ -116,6 +130,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php/?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/?foo=bar', $context['href']);
         $this->assertEquals('/', $context['pathname']);
     }
 
@@ -123,6 +138,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php/part?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part?foo=bar', $context['href']);
         $this->assertEquals('/part', $context['pathname']);
     }
 
@@ -130,6 +146,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar', $context['href']);
         $this->assertEquals('/part/sub', $context['pathname']);
     }
 
@@ -137,6 +154,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part/sub', $context['href']);
         $this->assertEquals('', $context['search']);
     }
 
@@ -144,6 +162,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part/sub?', $context['href']);
         $this->assertEquals('', $context['search']);
     }
 
@@ -151,6 +170,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar', $context['href']);
         $this->assertEquals('foo=bar', $context['search']);
     }
 
@@ -158,6 +178,7 @@ class GenericContextProviderTest extends TestCase
     {
         $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar&bar=baz');
         $context = $provider->getContext(false);
+        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar&bar=baz', $context['href']);
         $this->assertEquals('foo=bar&bar=baz', $context['search']);
     }
 }

--- a/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
+++ b/tests/Limenius/ReactRenderer/Tests/Context/GenericContextProviderTest.php
@@ -9,16 +9,16 @@ class GenericContextProviderTest extends TestCase
 {
     public function testGetHref()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/part/sub?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/part/sub?foo=bar', $context['href']);
     }
 
     public function testGetRequestUri1()
     {
-        $provider = new GenericContextProvider('https://example.com:443');
+        $provider = new GenericContextProvider('https://www.example.com:443');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:443', $context['href']);
+        $this->assertEquals('https://www.example.com:443', $context['href']);
         $this->assertEquals('/', $context['location']);
     }
 
@@ -32,9 +32,9 @@ class GenericContextProviderTest extends TestCase
 
     public function testGetRequestUri3()
     {
-        $provider = new GenericContextProvider('https://example.com:443/part');
+        $provider = new GenericContextProvider('https://www.example.com:443/part');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:443/part', $context['href']);
+        $this->assertEquals('https://www.example.com:443/part', $context['href']);
         $this->assertEquals('/part', $context['location']);
     }
 
@@ -48,17 +48,17 @@ class GenericContextProviderTest extends TestCase
 
     public function testGetRequestUri5()
     {
-        $provider = new GenericContextProvider('https://example.com:443/index.php/part?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:443/index.php/part?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:443/index.php/part?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:443/index.php/part?foo=bar', $context['href']);
         $this->assertEquals('/index.php/part?foo=bar', $context['location']);
     }
 
     public function testGetScheme1()
     {
-        $provider = new GenericContextProvider('http://example.com:443/part?foo=bar');
+        $provider = new GenericContextProvider('http://www.example.com:443/part?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('http://example.com:443/part?foo=bar', $context['href']);
+        $this->assertEquals('http://www.example.com:443/part?foo=bar', $context['href']);
         $this->assertEquals('http', $context['scheme']);
     }
 
@@ -80,19 +80,36 @@ class GenericContextProviderTest extends TestCase
 
     public function testGetHost2()
     {
+        $provider = new GenericContextProvider('https://www.example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('https://www.example.com:443/part?foo=bar', $context['href']);
+        $this->assertEquals('www.example.com', $context['host']);
+    }
+
+    public function testGetHost3()
+    {
         $provider = new GenericContextProvider('https://sub.example.com:443/part?foo=bar');
         $context = $provider->getContext(false);
         $this->assertEquals('https://sub.example.com:443/part?foo=bar', $context['href']);
         $this->assertEquals('sub.example.com', $context['host']);
     }
 
+    public function testGetHost4()
+    {
+        $provider = new GenericContextProvider('https://www.sub.example.com:443/part?foo=bar');
+        $context = $provider->getContext(false);
+        $this->assertEquals('https://www.sub.example.com:443/part?foo=bar', $context['href']);
+        $this->assertEquals('www.sub.example.com', $context['host']);
+    }
+
     public function testGetPort1()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/part?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/part?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/part?foo=bar', $context['href']);
         $this->assertEquals('8089', $context['port']);
     }
+
 
     public function testGetPort2()
     {
@@ -104,81 +121,81 @@ class GenericContextProviderTest extends TestCase
 
     public function testGetBaseUrl1()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/part?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/part?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/part?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/part?foo=bar', $context['href']);
         $this->assertEquals('', $context['base']);
     }
 
     public function testGetBaseUrl2()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php?foo=bar', $context['href']);
         $this->assertEquals('/index.php', $context['base']);
     }
 
     public function testGetPathName1()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/?foo=bar', $context['href']);
         $this->assertEquals('/', $context['pathname']);
     }
 
     public function testGetPathName2()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/?foo=bar', $context['href']);
         $this->assertEquals('/', $context['pathname']);
     }
 
     public function testGetPathName3()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/part?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/part?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/part?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/part?foo=bar', $context['href']);
         $this->assertEquals('/part', $context['pathname']);
     }
 
     public function testGetPathName4()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/part/sub?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/part/sub?foo=bar', $context['href']);
         $this->assertEquals('/part/sub', $context['pathname']);
     }
 
     public function testGetSearch1()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/part/sub');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/part/sub', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/part/sub', $context['href']);
         $this->assertEquals('', $context['search']);
     }
 
     public function testGetSearch2()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/part/sub?');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/part/sub?', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/part/sub?', $context['href']);
         $this->assertEquals('', $context['search']);
     }
 
     public function testGetSearch3()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/part/sub?foo=bar');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/part/sub?foo=bar', $context['href']);
         $this->assertEquals('foo=bar', $context['search']);
     }
 
     public function testGetSearch4()
     {
-        $provider = new GenericContextProvider('https://example.com:8089/index.php/part/sub?foo=bar&bar=baz');
+        $provider = new GenericContextProvider('https://www.example.com:8089/index.php/part/sub?foo=bar&bar=baz');
         $context = $provider->getContext(false);
-        $this->assertEquals('https://example.com:8089/index.php/part/sub?foo=bar&bar=baz', $context['href']);
+        $this->assertEquals('https://www.example.com:8089/index.php/part/sub?foo=bar&bar=baz', $context['href']);
         $this->assertEquals('foo=bar&bar=baz', $context['search']);
     }
 }


### PR DESCRIPTION
Added a GenericContextProvider for making this package usable for non-Symfony projects.

We are currently using this package as part of a Symfony project, and we would like to add it to a Wordpress project to enable react server side rendering. This GenericContextProvider let's do just that.