### PR TITLE
Allow twig >=2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.5.0",
         "nacmartin/phpexecjs": "^3.0",
-        "twig/twig": "^3.0"
+        "twig/twig": "^2.4|^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",


### PR DESCRIPTION
Only allowing support for Twig >= 3.0 is too much restrictive (in our case at least).
We can without problem add support for Twig >= 2.4 as namespace aliases was added there to ensure BC with the new class namespaces.